### PR TITLE
Pin Flocker version to 1.2.0

### DIFF
--- a/flocker-bits/flocker-core/Dockerfile
+++ b/flocker-bits/flocker-core/Dockerfile
@@ -2,15 +2,34 @@
 FROM ubuntu:14.04
 MAINTAINER Madhuri Yechuri <madhuri.yechuri@clusterhq.com>
 
+ENV FLOCKER_VERSION 1.2.0-1
+
 RUN sudo apt-get update
 RUN sudo apt-get -y install apt-transport-https software-properties-common
 RUN sudo add-apt-repository -y ppa:james-page/docker
 RUN sudo add-apt-repository -y "deb https://clusterhq-archive.s3.amazonaws.com/ubuntu/$(lsb_release --release --short)/\$(ARCH) /"
-RUN sudo apt-get update
-RUN sudo apt-get -y --force-yes install clusterhq-flocker-cli
-RUN sudo apt-get -y --force-yes install clusterhq-flocker-node
 
-RUN sudo apt-get -y --force-yes install git build-essential libncurses5-dev libslang2-dev gettext zlib1g-dev libselinux1-dev debhelper lsb-release pkg-config po-debconf autoconf automake autopoint libtool
+RUN sudo apt-get update && sudo apt-get -y --force-yes install \
+      clusterhq-python-flocker=${FLOCKER_VERSION} \
+      clusterhq-flocker-node=${FLOCKER_VERSION} \
+      clusterhq-flocker-node=${FLOCKER_VERSION}
+
+RUN sudo apt-get -y --force-yes install \
+      git \
+      build-essential \
+      libncurses5-dev \
+      libslang2-dev \
+      gettext \
+      zlib1g-dev \
+      libselinux1-dev \
+      debhelper \
+      lsb-release \
+      pkg-config \
+      po-debconf \
+      autoconf \
+      automake \
+      autopoint \
+      libtool
 
 RUN sudo git clone git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git util-linux
 RUN sudo bash -c "cd util-linux; \


### PR DESCRIPTION
This will pin the Flocker version for the `clusterhq/flocker-core` Docker image to version `1.2.0`. This makes it possible to tag images along with your binary releases.
