### PR TITLE
Add debug flags for mtab wrapper script

### DIFF
--- a/flocker-bits/dataset-agent/wrap_dataset_agent_mtab.sh
+++ b/flocker-bits/dataset-agent/wrap_dataset_agent_mtab.sh
@@ -6,14 +6,23 @@
 # prime it, before we go off into the backgrounded subshell
 unlink /etc/mtab
 /bin/nsenter --mount=/host/proc/1/ns/mnt -- cat /etc/mtab > /etc/mtab
->&2 echo "primed mtab"
+
+if [[ ${DEBUG} = "1" ]]
+then
+  >&2 echo "primed mtab"
+fi
 
 # update mtab atomically every second
 (
     while true; do
         /bin/nsenter --mount=/host/proc/1/ns/mnt -- cat /etc/mtab > /etc/mtab.tmp
         mv /etc/mtab.tmp /etc/mtab
-        >&2 echo "updated mtab"
+
+        if [[ ${DEBUG} = "1" ]]
+        then
+          >&2 echo "updated mtab"
+        fi
+
         sleep 1
     done
 ) &


### PR DESCRIPTION
This will add a debug flag in form of an environment variable to the mtab wrapper script.

By default debug output about `/etc/mtab` synchronization will be suppressed. As soon as a user passes the `DEBUG=1` environment variables to the process the output will be printed.
