### PR TITLE
use alpha AMIs for latest docker version

### DIFF
--- a/coreos-stable-hvm.template
+++ b/coreos-stable-hvm.template
@@ -1,47 +1,47 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "CoreOS on EC2: http://coreos.com/docs/running-coreos/cloud-providers/ec2/",
+  "Description": "CoreOS - Alpha Channel on EC2: http://coreos.com/docs/running-coreos/cloud-providers/ec2/",
   "Mappings" : {
       "RegionMap" : {
 
           "eu-central-1" : {
-              "AMI" : "ami-bececaa3"
+              "AMI" : "ami-4a484457"
           },
 
           "ap-northeast-1" : {
-              "AMI" : "ami-f2338ff2"
+              "AMI" : "ami-088ced08"
           },
 
           "us-gov-west-1" : {
-              "AMI" : "ami-c75033e4"
+              "AMI" : "ami-46543665"
           },
 
           "sa-east-1" : {
-              "AMI" : "ami-11e9600c"
+              "AMI" : "ami-05f76618"
           },
 
           "ap-southeast-2" : {
-              "AMI" : "ami-8f88c8b5"
+              "AMI" : "ami-8beaa1b1"
           },
 
           "ap-southeast-1" : {
-              "AMI" : "ami-b6d8d4e4"
+              "AMI" : "ami-7acede28"
           },
 
           "us-east-1" : {
-              "AMI" : "ami-3d73d356"
+              "AMI" : "ami-5182d534"
           },
 
           "us-west-2" : {
-              "AMI" : "ami-85ada4b5"
+              "AMI" : "ami-024baa31"
           },
 
           "us-west-1" : {
-              "AMI" : "ami-1db04f59"
+              "AMI" : "ami-8de828c9"
           },
 
           "eu-west-1" : {
-              "AMI" : "ami-0e104179"
+              "AMI" : "ami-e7281a90"
           }
 
       }


### PR DESCRIPTION
new AMI installs the following versions of coreos and docker.

tangentially solves weird concurrent image curruption download issue while running through uft tools. (because docker 1.6.X is no good with latest dockerhub?)

``` bash
core@ip-172-31-43-26 ~ $ cat /etc/os-release
NAME=CoreOS
ID=coreos
VERSION=835.1.0
VERSION_ID=835.1.0
BUILD_ID=
PRETTY_NAME="CoreOS 835.1.0"
ANSI_COLOR="1;32"
HOME_URL="https://coreos.com/"
BUG_REPORT_URL="https://github.com/coreos/bugs/issues"

core@ip-172-31-43-26 ~ $ docker -v
Docker version 1.8.3, build cedd534-dirty
```
