### PR TITLE
[FLOC-3467] Upgrade to Flocker 1.7.2

### DIFF
--- a/flocker-bits/buildimages.sh
+++ b/flocker-bits/buildimages.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-FLOCKER_TAG=1.5.0-1rev1
+set -e
+export FLOCKER_TAG=1.7.2
 docker build -t clusterhq/flocker-core:$FLOCKER_TAG flocker-core
 docker build -t clusterhq/flocker-container-agent:$FLOCKER_TAG container-agent
 docker build -t clusterhq/flocker-control-service:$FLOCKER_TAG control-agent

--- a/flocker-bits/buildimages.sh
+++ b/flocker-bits/buildimages.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
-docker build -t clusterhq/flocker-core flocker-core
-docker build -t clusterhq/flocker-container-agent container-agent
-docker build -t clusterhq/flocker-control-service control-agent
-docker build -t clusterhq/flocker-dataset-agent dataset-agent
-docker build -t clusterhq/flocker-tools flocker-tools
+FLOCKER_TAG=1.5.0-1rev1
+docker build -t clusterhq/flocker-core:$FLOCKER_TAG flocker-core
+docker build -t clusterhq/flocker-container-agent:$FLOCKER_TAG container-agent
+docker build -t clusterhq/flocker-control-service:$FLOCKER_TAG control-agent
+docker build -t clusterhq/flocker-dataset-agent:$FLOCKER_TAG dataset-agent
+docker build -t clusterhq/flocker-tools:$FLOCKER_TAG flocker-tools

--- a/flocker-bits/container-agent/Dockerfile
+++ b/flocker-bits/container-agent/Dockerfile
@@ -1,5 +1,5 @@
 # container-agent Dockerfile
-FROM clusterhq/flocker-core:1.2.0-1
+FROM clusterhq/flocker-core:1.7.2
 MAINTAINER Madhuri Yechuri <madhuri.yechuri@clusterhq.com>
 
 CMD ["/usr/sbin/flocker-container-agent"]

--- a/flocker-bits/control-agent/Dockerfile
+++ b/flocker-bits/control-agent/Dockerfile
@@ -1,5 +1,5 @@
 # control-service Dockerfile
-FROM clusterhq/flocker-core:1.2.0-1
+FROM clusterhq/flocker-core:1.7.2
 MAINTAINER Madhuri Yechuri <madhuri.yechuri@clusterhq.com>
 
 EXPOSE 4523-4524
@@ -7,4 +7,3 @@ RUN sudo bash -c "echo 'flocker-control-api 4523/tcp    # Flocker Control API po
 RUN sudo bash -c "echo 'flocker-control-agent   4525/tcp    # Flocker Control Agent port' >> /etc/services"
 
 CMD ["/usr/sbin/flocker-control", "-p", "tcp:4523", "-a", "tcp:4524"]
-

--- a/flocker-bits/dataset-agent/Dockerfile
+++ b/flocker-bits/dataset-agent/Dockerfile
@@ -1,5 +1,5 @@
 # dataset-agent Dockerfile
-FROM clusterhq/flocker-core:1.2.0-1
+FROM clusterhq/flocker-core:1.7.2
 MAINTAINER Madhuri Yechuri <madhuri.yechuri@clusterhq.com>
 
 ADD wrap_dataset_agent_mtab.sh /tmp/wrap_dataset_agent_mtab.sh

--- a/flocker-bits/flocker-core/Dockerfile
+++ b/flocker-bits/flocker-core/Dockerfile
@@ -2,7 +2,8 @@
 FROM ubuntu:14.04
 MAINTAINER Madhuri Yechuri <madhuri.yechuri@clusterhq.com>
 
-ENV FLOCKER_VERSION 1.2.0-1
+# Note: apt-get install requires the `-1` (epoch) suffix.
+ENV FLOCKER_VERSION 1.7.2-1
 
 RUN sudo apt-get update
 RUN sudo apt-get -y install apt-transport-https software-properties-common

--- a/flocker-bits/flocker-tools/Dockerfile
+++ b/flocker-bits/flocker-tools/Dockerfile
@@ -1,5 +1,5 @@
 # dataset-agent Dockerfile
-FROM clusterhq/flocker-core:1.2.0-1
+FROM clusterhq/flocker-core:1.7.2
 MAINTAINER Madhuri Yechuri <madhuri.yechuri@clusterhq.com>
 
 RUN sudo apt-get install -y python-pip build-essential libssl-dev libffi-dev python-dev


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-3467

For now I've updated the static version numbers in the various Dockerfiles beneath `/flocker-bits`.

I also added a new tag pattern matching rule to https://hub.docker.com/r/clusterhq/flocker-dataset-agent/~/settings/automated-builds/ as an example.

When this is merged I can create a 1.7.2 tag which should trigger an automated build on Docker Hub with the correct tag.

The `latest` tag will also be rebuilt as 1.7.2.

Perhaps we need a way to automate these version updates?

I investigated whether we could supply version as environment variable when running `docker build` but environment variables can't be included in `FROM` statements:
- http://docs.docker.com/engine/reference/builder/#environment-replacement

Another option might be:
- Update master Dockerfiles to refer to `:latest` tags.
- Maintain a `release-1.7` branch. 
- Use statements like `FROM clusterhq/flocker-core:1.7` 
- Merge non-flocker-version related changes  (eg changes to wrap_dataset_agent.sh) into  master and also then merge back into the release branch.
